### PR TITLE
Fixed a tiny mix-up among translations.

### DIFF
--- a/app/data/words.js
+++ b/app/data/words.js
@@ -1983,7 +1983,7 @@
   },
   {
     "word": "싸",
-    "translation": "expensive",
+    "translation": "cheap",
     "latin": "",
     "image": {
       "url": "",
@@ -2002,7 +2002,7 @@
   },
   {
     "word": "비싸",
-    "translation": "cheap",
+    "translation": "expensive",
     "latin": "",
     "image": {
       "url": "",


### PR DESCRIPTION
The translations for these two words next to each other seem to have been switched: 싸 means "cheap" and 비싸 means "expensive."